### PR TITLE
Allow multiple projects to be loaded simultaneously

### DIFF
--- a/src/main/java/org/nmrfx/processor/gui/PeakAttrController.java
+++ b/src/main/java/org/nmrfx/processor/gui/PeakAttrController.java
@@ -409,7 +409,7 @@ public class PeakAttrController implements Initializable, PeakNavigable, PeakMen
 
     public void updateConditionNames() {
         conditionField.getItems().clear();
-        Set<String> conditions = PeakList.peakListTable.values().stream().
+        Set<String> conditions = PeakList.peakListTable().values().stream().
                 map(peakList -> peakList.getSampleConditionLabel()).
                 filter(label -> label != null).collect(Collectors.toSet());
         conditions.stream().sorted().forEach(s -> {

--- a/src/main/java/org/nmrfx/processor/gui/PeakNavigator.java
+++ b/src/main/java/org/nmrfx/processor/gui/PeakNavigator.java
@@ -196,14 +196,14 @@ public class PeakNavigator implements PeakListener {
             updatePeakListMenu();
         };
 
-        PeakList.peakListTable.addListener(mapChangeListener);
+        PeakList.peakListTable().addListener(mapChangeListener);
 
     }
 
     public void updatePeakListMenu() {
         peakListMenuButton.getItems().clear();
 
-        for (String peakListName : PeakList.peakListTable.keySet()) {
+        for (String peakListName : PeakList.peakListTable().keySet()) {
             MenuItem menuItem = new MenuItem(peakListName);
             menuItem.setOnAction(e -> {
                 PeakNavigator.this.setPeakList(peakListName);

--- a/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -371,7 +371,7 @@ public class PolyChart implements PeakListener {
         MapChangeListener<String, PeakList> mapChangeListener = (MapChangeListener.Change<? extends String, ? extends PeakList> change) -> {
             purgeInvalidPeakListAttributes();
         };
-        PeakList.peakListTable.addListener(mapChangeListener);
+        PeakList.peakListTable().addListener(mapChangeListener);
         keyBindings = new KeyBindings(this);
         mouseBindings = new MouseBindings(this);
         gestureBindings = new GestureBindings(this);

--- a/src/main/java/org/nmrfx/processor/gui/tools/RunAboutGUI.java
+++ b/src/main/java/org/nmrfx/processor/gui/tools/RunAboutGUI.java
@@ -246,7 +246,7 @@ public class RunAboutGUI implements PeakListener {
             updatePeakListMenu();
         };
 
-        PeakList.peakListTable.addListener(mapChangeListener);
+        PeakList.peakListTable().addListener(mapChangeListener);
 
     }
 
@@ -258,7 +258,7 @@ public class RunAboutGUI implements PeakListener {
     public void updatePeakListMenu() {
         peakListMenuButton.getItems().clear();
 
-        for (String peakListName : PeakList.peakListTable.keySet()) {
+        for (String peakListName : PeakList.peakListTable().keySet()) {
             MenuItem menuItem = new MenuItem(peakListName);
             menuItem.setOnAction(e -> {
                 RunAboutGUI.this.setPeakList(peakListName);

--- a/src/main/java/org/nmrfx/project/GUIProject.java
+++ b/src/main/java/org/nmrfx/project/GUIProject.java
@@ -90,40 +90,51 @@ public class GUIProject extends Project {
     }
 
     public void loadGUIProject(Path projectDir) throws IOException, IllegalStateException {
+        Project currentProject=getActive();
+        setActive();
+
         loadProject(projectDir);
-        FileSystem fileSystem = FileSystems.getDefault();
 
-        String[] subDirTypes = {"windows"};
-        if (projectDir != null) {
-            for (String subDir : subDirTypes) {
-                Path subDirectory = fileSystem.getPath(projectDir.toString(), subDir);
-                if (Files.exists(subDirectory) && Files.isDirectory(subDirectory) && Files.isReadable(subDirectory)) {
-                    switch (subDir) {
-                        case "windows":
-                            loadWindows(subDirectory);
-                            break;
-                        default:
-                            throw new IllegalStateException("Invalid subdir type");
+        if(currentProject==this) {
+            FileSystem fileSystem = FileSystems.getDefault();
+
+            String[] subDirTypes = {"windows"};
+            if (projectDir != null) {
+                for (String subDir : subDirTypes) {
+                    Path subDirectory = fileSystem.getPath(projectDir.toString(), subDir);
+                    if (Files.exists(subDirectory) && Files.isDirectory(subDirectory) && Files.isReadable(subDirectory)) {
+                        switch (subDir) {
+                            case "windows":
+                                loadWindows(subDirectory);
+                                break;
+                            default:
+                                throw new IllegalStateException("Invalid subdir type");
+                        }
                     }
-                }
 
+                }
             }
         }
         this.projectDir = projectDir;
         PreferencesController.saveRecentProjects(projectDir.toString());
-
+        currentProject.setActive();
     }
 
     @Override
     public void saveProject() throws IOException {
+        Project currentProject=getActive();
+        setActive();
+
         if (projectDir == null) {
             throw new IllegalArgumentException("Project directory not set");
         }
         super.saveProject();
-        saveWindows();
+        if(currentProject==this) {
+            saveWindows();
+        }
         gitCommitOnThread();
         PreferencesController.saveRecentProjects(projectDir.toString());
-
+        currentProject.setActive();
     }
 
     void gitCommitOnThread() {

--- a/src/main/java/org/nmrfx/project/GUIProject.java
+++ b/src/main/java/org/nmrfx/project/GUIProject.java
@@ -50,6 +50,10 @@ public class GUIProject extends Project {
 
     public static GUIProject replace(String name, GUIProject project) {
         GUIProject newProject = new GUIProject(name);
+        newProject.datasetList=project.datasetList;
+        newProject.peakListTable=project.peakListTable;
+        newProject.resFactory=project.resFactory;
+        newProject.peakPaths=project.peakPaths;
         return newProject;
     }
 


### PR DESCRIPTION
The pull request for nmrfxprocessor describes the aims and strategy. It is pasted below for reference.

In nmrfxprocessorgui there are two changed required:

1) The project.replace method has been updated to account for the new Project instance variables.

2) GUIProject loadProject and saveProject methods updated to store the currently active project before making the owning object active, and then restore after the save or load is complete.  

3) Some references to PeakList.peakListTable have been updated to PeakList.peakListTable()


---------- pull request message from nmrfxprocessor ----------


With our workflow, being able to easily access other projects (e.g. fragments of a larger molecule) would be highly enabling. The forthcoming pull requests are a suggestion for how this might be achieved. I appreciate you will probably be wary of this and so for this initial pull request the changes are minimal - if you agree with this approach then I can suggest some additional changes which facilitate this type of workflow.

The reason that it is not currently possible to load multiple projects is that there are a number of static variables which store project information which are set when a project is loaded and read from when a project is saved. In nmrfxprocessor these are:

Dataset.theFiles
PeakList.peakListTable
PeakDim.resFactory
PeakPath.peakPaths

I have changed these to be instances of a Project object, so they can be independently managed between projects.

Dataset.theFiles -> theProject.datasetList
PeakList.peakListTable -> theProject.peakListTable
PeakDim.resFactory -> theProject.resFactory
PeakPath.peakPaths -> theProject.peakPaths

The original static variables have been converted to static methods which return the relevant variable from the active project. For example:

    private static HashMap<String, Dataset> theFiles = new HashMap<>();

Becomes:

    private static HashMap<String, Dataset> theFiles () {
        return Project.getActive().datasetList;
    }

And all references to Dataset.theFiles become Dataset.theFiles() .

The only other changes are in Project.java.

First, it is necessary that an active project is always return from Project.getActive(). If there is no activeProject, a new project is now created with the following precedence:

GUIStructureProject, StructureProject, GUIProject, Project

Finally, project.loadProject() and project.saveProject() store the currently active project before making the owning object active, and then restore after the save or load is complete.

In my testing, this allows me to load a project, and then (in Jython) do something like:

project1=Project("testproject1")
project1.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject1"))
project2=Project("testproject2")
project1.setActive()
project2.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject2"))

#access and modify peaklists, assignments etc. within each project

currentProject.saveProject()
subProject.saveProject()